### PR TITLE
Task generation on shuffle

### DIFF
--- a/atwork/clips/at-work-finals.clp
+++ b/atwork/clips/at-work-finals.clp
@@ -60,8 +60,8 @@
 
 (defclass AtWorkFinal2016 (is-a AtWorkFinal) (role concrete))
 
-(defmessage-handler AtWorkFinal2016 setup (?time ?state-machine)
-  (call-next-handler)
+(defmessage-handler AtWorkFinal2016 generate ()
+  (printout t "Generating new AtWorkFinal2016" crlf)
 
   (bind ?manipulation-robocup-objects ?*ROBOCUP-OBJECTS*)
   (bind ?manipulation-rockin-objects ?*ROCKIN-OBJECTS*)

--- a/atwork/clips/basic-manipulation-tests.clp
+++ b/atwork/clips/basic-manipulation-tests.clp
@@ -60,8 +60,8 @@
 
 (defclass BasicManipulationTest1 (is-a BasicManipulationTest) (role concrete))
 
-(defmessage-handler BasicManipulationTest1 setup (?time ?state-machine)
-  (call-next-handler)
+(defmessage-handler BasicManipulationTest1 generate ()
+  (printout t "Generating new BasicManipulationTest1" crlf)
 
   (bind ?manipulation-robocup-objects ?*ROBOCUP-OBJECTS*)
   

--- a/atwork/clips/basic-navigation-tests.clp
+++ b/atwork/clips/basic-navigation-tests.clp
@@ -61,8 +61,8 @@
 
 (defclass BasicNavigationTest1 (is-a BasicNavigationTest) (role concrete))
 
-(defmessage-handler BasicNavigationTest1 setup (?time ?state-machine)
-  (call-next-handler)
+(defmessage-handler BasicNavigationTest1 generate ()
+  (printout t "Generating new BasicNavigationTest1" crlf)
 
   (bind ?navigation-locations (create$
         ?*WORKSTATION-0CM-LOCATIONS* ?*WORKSTATION-5CM-LOCATIONS*

--- a/atwork/clips/basic-transportation-tests.clp
+++ b/atwork/clips/basic-transportation-tests.clp
@@ -58,13 +58,11 @@
 
 (defclass BasicTransportationTest1 (is-a BasicTransportationTest) (role concrete))
 
-(defmessage-handler BasicTransportationTest1 setup (?time ?state-machine)
-  (call-next-handler)
+(defmessage-handler BasicTransportationTest1 generate ()
+  (printout t "Generating new BasicTransportationTest1" crlf)
 
   (bind ?transportation-objects ?*ROBOCUP-OBJECTS*)
-
   (bind ?decoy-objects (create$ ?*ROBOCUP-OBJECTS* ?*ROCKIN-OBJECTS*))
-
   (bind ?workstation-locations ?*WORKSTATION-10CM-LOCATIONS*)
 
   ; Source locations must exist before adding to it.
@@ -114,8 +112,8 @@
 
 (defclass BasicTransportationTest2 (is-a BasicTransportationTest) (role concrete))
 
-(defmessage-handler BasicTransportationTest2 setup (?time ?state-machine)
-  (call-next-handler)
+(defmessage-handler BasicTransportationTest2 generate ()
+  (printout t "Generating new BasicTransportationTest2" crlf)
 
   (bind ?robocup-objects          ?*ROBOCUP-OBJECTS*)
   (bind ?rockin-objects           ?*ROCKIN-OBJECTS*)
@@ -240,8 +238,8 @@
 
 (defclass BasicTransportationTest3 (is-a BasicTransportationTest) (role concrete))
 
-(defmessage-handler BasicTransportationTest3 setup (?time ?state-machine)
-  (call-next-handler)
+(defmessage-handler BasicTransportationTest3 generate ()
+  (printout t "Generating new BasicTransportationTest3" crlf)
 
   ; Get Globals
   (bind ?robocup-objects                ?*ROBOCUP-OBJECTS*)

--- a/atwork/clips/benchmark.clp
+++ b/atwork/clips/benchmark.clp
@@ -33,6 +33,8 @@
 (defmessage-handler BenchmarkScenario setup (?time ?state-machine)
 )
 
+(defmessage-handler BenchmarkScenario generate ())
+
 (defmessage-handler BenchmarkScenario handle-feedback (?pb-msg ?time ?name ?team)
   (return CONTINUE)
 )
@@ -62,10 +64,7 @@
   (slot state-machine (type INSTANCE) (allowed-classes StateMachine))
 )
 
-(defmessage-handler Benchmark switch-scenario ()
-  (send ?self put-current-scenario ?self:requested-scenario)
-
-
+(defmessage-handler Benchmark cleanup ()
   ; Remove all items from the inventory
   (do-for-all-instances ((?inventory Inventory))
     (foreach ?item (send ?inventory get-items)
@@ -100,10 +99,16 @@
     (slot-delete$ ?task-info tasks 1 (length$ (send ?task-info get-tasks)))
   )
 
-
   ; TODO: Remove all states and their transitions
 
+)
 
+(defmessage-handler Benchmark switch-scenario ()
+  (if (neq ?self:current-scenario ?self:requested-scenario) then
+    (send ?self put-current-scenario ?self:requested-scenario)
+    (send ?self cleanup)
+    (send ?self:current-scenario generate)
+  )
   (send ?self:current-scenario setup ?self:time ?self:state-machine)
 )
 

--- a/atwork/clips/conveyor-belt-tests.clp
+++ b/atwork/clips/conveyor-belt-tests.clp
@@ -60,8 +60,8 @@
 
 (defclass ConveyorBeltTest1 (is-a ConveyorBeltTest) (role concrete))
 
-(defmessage-handler ConveyorBeltTest1 setup (?time ?state-machine)
-  (call-next-handler)
+(defmessage-handler ConveyorBeltTest1 generate ()
+  (printout t "Generating new ConveyorBeltTest1" crlf)
 
   (bind ?manipulation-objects ?*ROBOCUP-OBJECTS*)
   (bind ?source-location [conveyorbelt-01])
@@ -93,8 +93,8 @@
 
 (defclass ConveyorBeltTest2 (is-a ConveyorBeltTest) (role concrete))
 
-(defmessage-handler ConveyorBeltTest2 setup (?time ?state-machine)
-  (call-next-handler)
+(defmessage-handler ConveyorBeltTest2 generate ()
+  (printout t "Generating new ConveyorBeltTest2" crlf)
 
   (bind ?manipulation-objects ?*ROBOCUP-OBJECTS*)
   (bind ?source-location [conveyorbelt-02])

--- a/atwork/clips/net.clp
+++ b/atwork/clips/net.clp
@@ -213,12 +213,22 @@
 
   (bind ?pb-event (pb-field-value ?p "event"))
 
-  (if (eq ?pb-event RESET) then
-    (send [benchmark] switch-scenario)
-  else
-    (printout t "RECV TRANSITION EVENT: " ?pb-event crlf)
-    (bind ?state-machine (send [benchmark] get-state-machine))
-    (send ?state-machine process-event ?pb-event)
+  (switch ?pb-event
+    (case RESET then
+      (send [benchmark] switch-scenario))
+    (case SHUFFLE then
+      (bind ?current-scenario (send [benchmark] get-current-scenario))
+      (send [benchmark] cleanup)
+      (send ?current-scenario generate))
+    (case SKIP then
+      (bind ?state-machine (send [benchmark] get-state-machine))
+      (send ?state-machine process-event STOP)
+      (send ?state-machine process-event START)
+    )
+    (default
+      (printout t "RECV TRANSITION EVENT: " ?pb-event crlf)
+      (bind ?state-machine (send [benchmark] get-state-machine))
+      (send ?state-machine process-event ?pb-event))
   )
 )
 

--- a/atwork/clips/precision-placement-tests.clp
+++ b/atwork/clips/precision-placement-tests.clp
@@ -60,8 +60,8 @@
 
 (defclass PrecisionPlacementTest1 (is-a PrecisionPlacementTest) (role concrete))
 
-(defmessage-handler PrecisionPlacementTest1 setup (?time ?state-machine)
-  (call-next-handler)
+(defmessage-handler PrecisionPlacementTest1 generate ()
+  (printout t "Generating new PrecisionPlacementTest1" crlf)
 
   (bind ?precision-objects ?*ROBOCUP-OBJECTS*)
   (bind ?source-locations ?*WORKSTATION-10CM-LOCATIONS*)

--- a/atwork/controller/atwork-controller.cpp
+++ b/atwork/controller/atwork-controller.cpp
@@ -8,6 +8,7 @@
 #include <utils/system/argparser.h>
 
 #include <protobuf_comm/client.h>
+#include <msgs/BenchmarkControl.pb.h>
 #include <msgs/BenchmarkState.pb.h>
 #include <msgs/ConveyorBelt.pb.h>
 
@@ -55,27 +56,37 @@ bool idle_handler() {
     Gtk::Button *button_start = 0;
     Gtk::Button *button_pause = 0;
     Gtk::Button *button_stop = 0;
+    Gtk::Button *button_shuffle= 0;
+    Gtk::Button *button_next = 0;
     builder->get_widget("button_start", button_start);
     builder->get_widget("button_pause", button_pause);
     builder->get_widget("button_stop", button_stop);
+    builder->get_widget("button_shuffle", button_shuffle);
+    builder->get_widget("button_next", button_next);
 
     switch (benchmark_state->state()) {
       case atwork_pb_msgs::BenchmarkState::STOPPED:
         button_start->set_sensitive(true);
         button_pause->set_sensitive(false);
         button_stop->set_sensitive(false);
+        button_shuffle->set_sensitive(true);
+        button_next->set_sensitive(false);
       break;
 
       case atwork_pb_msgs::BenchmarkState::RUNNING:
         button_start->set_sensitive(false);
         button_pause->set_sensitive(true);
         button_stop->set_sensitive(true);
+        button_shuffle->set_sensitive(false);
+        button_next->set_sensitive(true);
       break;
 
       case atwork_pb_msgs::BenchmarkState::PAUSED:
         button_start->set_sensitive(true);
         button_pause->set_sensitive(false);
         button_stop->set_sensitive(false);
+        button_shuffle->set_sensitive(false);
+        button_next->set_sensitive(false);
       break;
 
       case atwork_pb_msgs::BenchmarkState::FINISHED:
@@ -83,10 +94,14 @@ bool idle_handler() {
             button_start->set_sensitive(false);
             button_pause->set_sensitive(false);
             button_stop->set_sensitive(false);
+            button_shuffle->set_sensitive(false);
+            button_next->set_sensitive(false);
         } else {
             button_start->set_sensitive(true);
             button_pause->set_sensitive(false);
             button_stop->set_sensitive(false);
+            button_shuffle->set_sensitive(false);
+            button_next->set_sensitive(false);
         }
       break;
     }
@@ -128,6 +143,26 @@ void on_stop_click()
 
   atwork_pb_msgs::SetBenchmarkTransitionEvent cmd_event;
   cmd_event.set_event(atwork_pb_msgs::SetBenchmarkTransitionEvent::STOP);
+  client.send(cmd_event);
+}
+
+
+void on_shuffle_click()
+{
+  if (!client.connected()) return;
+
+  atwork_pb_msgs::SetBenchmarkTransitionEvent cmd_event;
+  cmd_event.set_event(atwork_pb_msgs::SetBenchmarkTransitionEvent::SHUFFLE);
+  client.send(cmd_event);
+}
+
+
+void on_next_click()
+{
+  if (!client.connected()) return;
+
+  atwork_pb_msgs::SetBenchmarkTransitionEvent cmd_event;
+  cmd_event.set_event(atwork_pb_msgs::SetBenchmarkTransitionEvent::SKIP);
   client.send(cmd_event);
 }
 
@@ -223,12 +258,16 @@ int main(int argc, char **argv)
   Gtk::Button *button_start = 0;
   Gtk::Button *button_pause = 0;
   Gtk::Button *button_stop = 0;
+  Gtk::Button *button_shuffle= 0;
+  Gtk::Button *button_next = 0;
   Gtk::Button *button_reset = 0;
   Gtk::Button *button_cb_start = 0;
   Gtk::Button *button_cb_stop = 0;
   builder->get_widget("button_start", button_start);
   builder->get_widget("button_pause", button_pause);
   builder->get_widget("button_stop", button_stop);
+  builder->get_widget("button_shuffle", button_shuffle);
+  builder->get_widget("button_next", button_next);
   builder->get_widget("button_reset", button_reset);
   builder->get_widget("button_cb_start", button_cb_start);
   builder->get_widget("button_cb_stop", button_cb_stop);
@@ -237,6 +276,8 @@ int main(int argc, char **argv)
   button_start->signal_clicked().connect(sigc::ptr_fun(&on_start_click));
   button_pause->signal_clicked().connect(sigc::ptr_fun(&on_pause_click));
   button_stop->signal_clicked().connect(sigc::ptr_fun(&on_stop_click));
+  button_shuffle->signal_clicked().connect(sigc::ptr_fun(&on_shuffle_click));
+  button_next->signal_clicked().connect(sigc::ptr_fun(&on_next_click));
   button_reset->signal_clicked().connect(sigc::ptr_fun(&on_reset_click));
   button_cb_start->signal_clicked().connect(sigc::ptr_fun(&on_cb_start_click));
   button_cb_stop->signal_clicked().connect(sigc::ptr_fun(&on_cb_stop_click));

--- a/atwork/controller/atwork_controller.glade
+++ b/atwork/controller/atwork_controller.glade
@@ -12,6 +12,11 @@
     <property name="can_focus">False</property>
     <property name="stock">gtk-media-stop</property>
   </object>
+  <object class="GtkImage" id="image_ctrl_next">
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+    <property name="stock">gtk-media-next</property>
+  </object>
   <object class="GtkImage" id="image_ctrl_pause">
     <property name="visible">True</property>
     <property name="can_focus">False</property>
@@ -21,6 +26,11 @@
     <property name="visible">True</property>
     <property name="can_focus">False</property>
     <property name="stock">gtk-media-play</property>
+  </object>
+  <object class="GtkImage" id="image_ctrl_shuffle">
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+    <property name="stock">gtk-refresh</property>
   </object>
   <object class="GtkImage" id="image_ctrl_stop">
     <property name="visible">True</property>
@@ -50,19 +60,63 @@
                 <property name="left_padding">12</property>
                 <property name="right_padding">12</property>
                 <child>
-                  <object class="GtkBox" id="box6">
+                  <object class="GtkBox" id="box10">
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
-                    <property name="homogeneous">True</property>
+                    <property name="orientation">vertical</property>
                     <child>
-                      <object class="GtkButton" id="button_start">
-                        <property name="label" translatable="yes">Start</property>
+                      <object class="GtkBox" id="box6">
                         <property name="visible">True</property>
-                        <property name="sensitive">False</property>
-                        <property name="can_focus">True</property>
-                        <property name="receives_default">True</property>
-                        <property name="image">image_ctrl_play</property>
-                        <property name="image_position">top</property>
+                        <property name="can_focus">False</property>
+                        <property name="homogeneous">True</property>
+                        <child>
+                          <object class="GtkButton" id="button_start">
+                            <property name="label" translatable="yes">Start</property>
+                            <property name="visible">True</property>
+                            <property name="sensitive">False</property>
+                            <property name="can_focus">True</property>
+                            <property name="receives_default">True</property>
+                            <property name="image">image_ctrl_play</property>
+                            <property name="image_position">top</property>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">True</property>
+                            <property name="position">0</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkButton" id="button_pause">
+                            <property name="label" translatable="yes">Pause</property>
+                            <property name="visible">True</property>
+                            <property name="sensitive">False</property>
+                            <property name="can_focus">True</property>
+                            <property name="receives_default">True</property>
+                            <property name="image">image_ctrl_pause</property>
+                            <property name="image_position">top</property>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">True</property>
+                            <property name="position">1</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkButton" id="button_stop">
+                            <property name="label" translatable="yes">Stop</property>
+                            <property name="visible">True</property>
+                            <property name="sensitive">False</property>
+                            <property name="can_focus">True</property>
+                            <property name="receives_default">True</property>
+                            <property name="image">image_ctrl_stop</property>
+                            <property name="image_position">top</property>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">True</property>
+                            <property name="position">2</property>
+                          </packing>
+                        </child>
                       </object>
                       <packing>
                         <property name="expand">False</property>
@@ -71,35 +125,47 @@
                       </packing>
                     </child>
                     <child>
-                      <object class="GtkButton" id="button_pause">
-                        <property name="label" translatable="yes">Pause</property>
+                      <object class="GtkBox" id="box11">
                         <property name="visible">True</property>
-                        <property name="sensitive">False</property>
-                        <property name="can_focus">True</property>
-                        <property name="receives_default">True</property>
-                        <property name="image">image_ctrl_pause</property>
-                        <property name="image_position">top</property>
+                        <property name="can_focus">False</property>
+                        <property name="homogeneous">True</property>
+                        <child>
+                          <object class="GtkButton" id="button_shuffle">
+                            <property name="label" translatable="yes">Shuffle</property>
+                            <property name="visible">True</property>
+                            <property name="sensitive">False</property>
+                            <property name="can_focus">True</property>
+                            <property name="receives_default">True</property>
+                            <property name="image">image_ctrl_shuffle</property>
+                            <property name="image_position">top</property>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">True</property>
+                            <property name="position">0</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkButton" id="button_next">
+                            <property name="label" translatable="yes">Next</property>
+                            <property name="visible">True</property>
+                            <property name="sensitive">False</property>
+                            <property name="can_focus">True</property>
+                            <property name="receives_default">True</property>
+                            <property name="image">image_ctrl_next</property>
+                            <property name="image_position">top</property>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">True</property>
+                            <property name="position">1</property>
+                          </packing>
+                        </child>
                       </object>
                       <packing>
                         <property name="expand">False</property>
                         <property name="fill">True</property>
                         <property name="position">1</property>
-                      </packing>
-                    </child>
-                    <child>
-                      <object class="GtkButton" id="button_stop">
-                        <property name="label" translatable="yes">Stop</property>
-                        <property name="visible">True</property>
-                        <property name="sensitive">False</property>
-                        <property name="can_focus">True</property>
-                        <property name="receives_default">True</property>
-                        <property name="image">image_ctrl_stop</property>
-                        <property name="image_position">top</property>
-                      </object>
-                      <packing>
-                        <property name="expand">False</property>
-                        <property name="fill">True</property>
-                        <property name="position">2</property>
                       </packing>
                     </child>
                   </object>

--- a/atwork/msgs/BenchmarkState.proto
+++ b/atwork/msgs/BenchmarkState.proto
@@ -136,6 +136,12 @@ message SetBenchmarkTransitionEvent {
 
     // Transition from RUNNING to PAUSED state
     PAUSE = 3;
+
+    // STOP the current state and START the next state
+    SKIP = 4;
+
+    // Trigger Task & Invetory generation for the current benchmark scenario
+    SHUFFLE = 5;
   }
 
   // The requested transition


### PR DESCRIPTION
## nutshell

adds two buttons: shuffle and next.
## details
- In SetTransitionEvent
  - SKIP is a short-cut for Stop then Start
    - for example, useful when team says they're finished with prep time.
  - SHUFFLE is to trigger generation of tasks
  - In mind for naming was [standard media player buttons](https://en.wikipedia.org/wiki/Media_controls)
- In atwork-controller GUI:
  - Shuffle to trigger task generation
  - Next = send Stop followed by Start
- In net.clp:
  - switch on received transition events
    - reset & else are same
    - added SHUFFLE to cleanup and send generate
    - added SKIP to send STOP followed by START
- In benchmark.clp:
  - moves cleanup code from switch-scenario to cleanup
  - adds check in switch-scenario:
    - if requested scenario is different then:
      - set new scenario and cleanup
      - generate new scenario
    - send setup to current state-machine to reset it
  - adds empty generate message handler to BenchmarkScenario
- In ALL TEST INSTANCE CLASSES:
  - move setup code to generate and only use superclass setup.
  - Adds printout when generating new scenarios
